### PR TITLE
Config handling both email+password & access_token

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,12 +18,11 @@ This is a Telegram bot that allows you to interact with ChatGPT, an advanced cha
 
 2. Get your Telegram bot token from [@BotFather](https://t.me/BotFather)
 
-3. Edit `config/config.example.yml` to set your telegram token and OpenAI credentials and run 2 commands below (*if you're advanced user, you can also edit* `config/config.example.env`):
+3. Edit `config/config.example.yml` to set your telegram token and OpenAI credentials (email and password or [OpenAI access_token](https://chat.openai.com/api/auth/session)) and run 2 commands below (*if you're advanced user, you can also edit* `config/config.example.env`):
 ```bash
 mv config/config.example.yml config/config.yml
 mv config/config.example.env config/config.env
 ```
-UPD 01.04.23: config now works only via [OpenAi access_token](https://chat.openai.com/api/auth/session)
 
 And now **run**:
 

--- a/bot/chatgpt.py
+++ b/bot/chatgpt.py
@@ -13,6 +13,10 @@ class ChatGPT:
     def __init__(self):
         self.chatbot = Chatbot(
             config={
+                "email": config.openai_login,
+                "password": config.openai_password
+            } if config.openai_login and config.openai_password else
+            {
                 "access_token": config.openai_access_token
             }
         )

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,4 +5,3 @@ python-telegram-bot[rate-limiter]==20.1
 PyYAML==6.0
 revChatGPT
 tiktoken>=0.3.0
-pydub==0.25.1


### PR DESCRIPTION
Updated chatGPT config to handle one of the provided options: email+password or access_token