### PR TITLE
Pyright dialog_messages type hint fix

### DIFF
--- a/bot/chatgpt.py
+++ b/bot/chatgpt.py
@@ -34,7 +34,7 @@ class ChatGPT:
             chat_mode: str = "assistant"
     ):
         if dialog_messages is None:
-            dialog_messages: list[str] = []
+            dialog_messages = []
 
         if chat_mode not in CHAT_MODES.keys():
             raise ValueError(f"Chat mode {chat_mode} is not supported")


### PR DESCRIPTION
fixed parameter 'dialog_messages' declaration is obscured by a declaation of the same name error